### PR TITLE
add analytics id

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -108,7 +108,7 @@ JB :
     gauges :
         site_id : 'SITE ID'
     google :
-        tracking_id : 'UA-123-12'
+        tracking_id : 'UA-49233464-3'
     getclicky :
       site_id :
     mixpanel :


### PR DESCRIPTION
The current config was the default Jekyll GA tracking id, and this replaces it with our GA tracking id.
